### PR TITLE
Proposta de alteração da extension da classe Date

### DIFF
--- a/Source/Foundation+Extensions/Date.swift
+++ b/Source/Foundation+Extensions/Date.swift
@@ -56,9 +56,11 @@ public extension Date {
     - See Also [NSDateFormatter](http://nsdateformatter.com/)
     - parameter format: String date format
     - parameter timeZone: TimeZone to set the correct timestemp if needed
+    - parameter locale: Locale to set the correct locale if needed
     */
-   func stringBy(format: String, timeZone: TimeZone = TimeZone.current) -> String {
+   func stringBy(format: String, timeZone: TimeZone = .current, locale: Locale = .current) -> String {
       let dateFormatter = DateFormatter()
+      dateFormatter.locale = locale
       dateFormatter.dateFormat = format
       dateFormatter.timeZone = timeZone
       return dateFormatter.string(from: self)


### PR DESCRIPTION
Incluir possibilidade de alteração da localização no método `stringBy` extension de Date.
Atualmente sempre retorna meses em inglês.